### PR TITLE
feat: upgrade crate secp256k1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 hex = "0.4"
 parity-scale-codec = { version = "3.2", default-features = false, features = ["derive"] }
-sp-core = { version = "6.0", default-features = false, features = ["std", "full_crypto"] }
+sp-core = { version = "11.0", default-features = false, features = ["std", "full_crypto"] }
 primitive-types = { version = "0.12", default-features = false, features = ["codec", "scale-info", "serde"] }
 serde = "1"
 serde_json = "1"
@@ -21,5 +21,5 @@ thiserror = "1"
 
 [dev-dependencies]
 paste = "1"
-secp256k1 = { version = "0.20.3", features = ["recovery"] }
+secp256k1 = { version = "0.25", features = ["recovery"] }
 ureq = { version = "2.3", features = ["json"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -46,7 +46,7 @@ impl Signer for KeyStore {
         let message = Message::from_slice(&digest)?;
 
         let (rec_id, compact) = secp
-            .sign_recoverable(&message, &self.key)
+            .sign_ecdsa_recoverable(&message, &self.key)
             .serialize_compact();
         let mut sig = [0; 65];
         sig[0..64].copy_from_slice(&compact);

--- a/tests/integrations/main.rs
+++ b/tests/integrations/main.rs
@@ -49,7 +49,7 @@ impl Signer for KeyStore {
         let message = Message::from_slice(&digest)?;
 
         let (rec_id, compact) = secp
-            .sign_recoverable(&message, &self.key)
+            .sign_ecdsa_recoverable(&message, &self.key)
             .serialize_compact();
         let mut sig = [0; 65];
         sig[0..64].copy_from_slice(&compact);


### PR DESCRIPTION
As there is a vulnerability found in secp256k1 v0.20.3 and v0.21.3, this commit upgrades the crate version. sp-core is upgraded as well as there is a transitive dependency on secp256k1.

vulnerability ref: https://github.com/advisories/GHSA-969w-q74q-9j8v