### PR TITLE
remove controller parameter for staking stash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,26 +14,27 @@ edition = "2021"
 base58 = "0.2"
 blake2 = "0.10"
 hex = "0.4"
-parity-scale-codec = { version = "3.2", default-features = false, features = [
-    "derive",
-] }
-
-sp-core = { default-features = false, features = [
-    "full_crypto",
-    "serde",
-], git = "https://github.com/paritytech/substrate.git", rev = "713e34a" }
-sp-storage = { default-features = false, features = [
-    "serde",
-], git = "https://github.com/paritytech/substrate.git", rev = "713e34a" }
-
-primitive-types = { version = "0.12", default-features = false, features = [
-    "codec",
-    "scale-info",
-    "serde",
-] }
+primitive-types = { version = "0.12", default-features = false, features = ["codec","scale-info","serde"] }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
+
+[dependencies.parity-scale-codec]
+version = "3.2"
+default-features = false
+features = ["derive"]
+
+[dependencies.sp-core]
+default-features = false
+features = ["full_crypto", "serde"]
+git = "https://github.com/paritytech/substrate.git"
+rev = "713e34a"
+
+[dependencies.sp-storage]
+default-features = false
+features = ["serde"]
+git = "https://github.com/paritytech/substrate.git"
+rev = "713e34a"
 
 [dev-dependencies]
 paste = "1"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -128,18 +128,7 @@ fn main() {
 
     // staking bond
     let bond_xt_hex = api
-        .staking_bond(
-            MultiAddress::Id(
-                AccountId32::from_ss58check_with_version(
-                    "5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe",
-                )
-                .unwrap()
-                .0,
-            ),
-            1000,
-            RewardDestination::Stash,
-            None,
-        )
+        .staking_bond(1000, RewardDestination::Stash, None)
         .expect("Created xt")
         .as_hex();
     dbg!(&bond_xt_hex);
@@ -183,18 +172,7 @@ fn main() {
     dbg!(fees);
 
     let bond_xt_hex = api
-        .staking_bond(
-            MultiAddress::Id(
-                AccountId32::from_ss58check_with_version(
-                    "5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe",
-                )
-                .unwrap()
-                .0,
-            ),
-            1000,
-            RewardDestination::Stash,
-            None,
-        )
+        .staking_bond(1000, RewardDestination::Stash, None)
         .expect("Created xt")
         .as_hex();
     dbg!(&bond_xt_hex);

--- a/src/network.rs
+++ b/src/network.rs
@@ -21,7 +21,6 @@ pub trait SubstrateNetwork: Clone + Copy + 'static {
     const STAKING_WITHDRAW_UNBONDED: u8 = 3;
     const STAKING_NOMINATE: u8 = 5;
     const STAKING_CHILL: u8 = 6;
-    const STAKING_SET_CONTROLLER: u8 = 8;
     const STAKING_REBOND: u8 = 19;
 
     // Proxy Pallet

--- a/src/pallets/staking.rs
+++ b/src/pallets/staking.rs
@@ -8,7 +8,6 @@ use crate::{Balance, GenericAddress, UncheckedExtrinsic};
 
 pub type ComposedStakingBond = (
     CallIndex,
-    GenericAddress,
     Compact<Balance>,
     RewardDestination<GenericAddress>,
 );
@@ -17,7 +16,6 @@ pub type ComposedStakingUnbond = (CallIndex, Compact<Balance>);
 pub type ComposedStakingWithdrawUnbonded = (CallIndex, u32);
 pub type ComposedStakingNominate = (CallIndex, Vec<GenericAddress>);
 pub type ComposedStakingChill = CallIndex;
-pub type ComposedStakingSetController = (CallIndex, GenericAddress);
 pub type ComposedStakingRebond = (CallIndex, Compact<Balance>);
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Encode, Decode)]
@@ -32,14 +30,12 @@ pub enum RewardDestination<Account> {
 impl<S: Signer, Client: RpcClient, N: SubstrateNetwork> Api<'_, S, Client, N> {
     pub fn staking_bond(
         &self,
-        controller: GenericAddress,
         amount: Balance,
         payee: RewardDestination<GenericAddress>,
         nonce: Option<u32>,
     ) -> Result<UncheckedExtrinsic<ComposedStakingBond>> {
         let call = (
             [N::STAKING_PALLET_IDX, N::STAKING_BOND],
-            controller,
             Compact(amount),
             payee,
         );
@@ -93,18 +89,6 @@ impl<S: Signer, Client: RpcClient, N: SubstrateNetwork> Api<'_, S, Client, N> {
         nonce: Option<u32>,
     ) -> Result<UncheckedExtrinsic<ComposedStakingChill>> {
         self._create_xt([N::STAKING_PALLET_IDX, N::STAKING_CHILL], nonce)
-    }
-
-    pub fn staking_set_controller(
-        &self,
-        controller: GenericAddress,
-        nonce: Option<u32>,
-    ) -> Result<UncheckedExtrinsic<ComposedStakingSetController>> {
-        let call = (
-            [N::STAKING_PALLET_IDX, N::STAKING_SET_CONTROLLER],
-            controller,
-        );
-        self._create_xt(call, nonce)
     }
 
     pub fn staking_rebond(

--- a/tests/integrations/kusama.rs
+++ b/tests/integrations/kusama.rs
@@ -27,17 +27,10 @@ validate_xt!(
     balance_transfer("GvWdZbtNY8nSFBfZ2Jr9V8hdo2F84jPdn8BBV55AQtgUsjq"),
     "0x040000c05740c342cde29bac622eba115bca3c9d2d194ef52aac55c58208cfbff8a931a10f"
 );
-validate_xt!(
-    staking_bond("GvWdZbtNY8nSFBfZ2Jr9V8hdo2F84jPdn8BBV55AQtgUsjq"),
-    "0x060000c05740c342cde29bac622eba115bca3c9d2d194ef52aac55c58208cfbff8a931a10f01"
-);
+validate_xt!(staking_bond(), "0x0600a10f01");
 validate_xt!(
     staking_nominate("GvWdZbtNY8nSFBfZ2Jr9V8hdo2F84jPdn8BBV55AQtgUsjq"),
     "0x06050400c05740c342cde29bac622eba115bca3c9d2d194ef52aac55c58208cfbff8a931"
-);
-validate_xt!(
-    staking_set_controller("GvWdZbtNY8nSFBfZ2Jr9V8hdo2F84jPdn8BBV55AQtgUsjq"),
-    "0x060800c05740c342cde29bac622eba115bca3c9d2d194ef52aac55c58208cfbff8a931"
 );
 validate_xt!(
     proxy_add_proxy("GvWdZbtNY8nSFBfZ2Jr9V8hdo2F84jPdn8BBV55AQtgUsjq"),

--- a/tests/integrations/main.rs
+++ b/tests/integrations/main.rs
@@ -108,6 +108,7 @@ macro_rules! validate_xt {
             #[test]
             fn  [<test_ $call _fee>]() {
                 let xt = $crate::xt::$call(&API, $($args)*).as_hex();
+                dbg!(&xt);
                 let res = API.fee_details(&xt, None);
                 dbg!(&res);
                 assert!(res.is_ok());

--- a/tests/integrations/polkadot.rs
+++ b/tests/integrations/polkadot.rs
@@ -27,17 +27,10 @@ validate_xt!(
     balance_transfer("15FEzAVAanaAGtVZLEDMeRKdKipwQrTCpJd1k6k4WP4LhXgT"),
     "0x050000bbcd72f9f3d1782b57e512497ed7a1d3e2163333bb06c59723e28823798f5a7da10f"
 );
-validate_xt!(
-    staking_bond("15FEzAVAanaAGtVZLEDMeRKdKipwQrTCpJd1k6k4WP4LhXgT"),
-    "0x070000bbcd72f9f3d1782b57e512497ed7a1d3e2163333bb06c59723e28823798f5a7da10f01"
-);
+validate_xt!(staking_bond(), "0x0700a10f01");
 validate_xt!(
     staking_nominate("15FEzAVAanaAGtVZLEDMeRKdKipwQrTCpJd1k6k4WP4LhXgT"),
     "0x07050400bbcd72f9f3d1782b57e512497ed7a1d3e2163333bb06c59723e28823798f5a7d"
-);
-validate_xt!(
-    staking_set_controller("15FEzAVAanaAGtVZLEDMeRKdKipwQrTCpJd1k6k4WP4LhXgT"),
-    "0x070800bbcd72f9f3d1782b57e512497ed7a1d3e2163333bb06c59723e28823798f5a7d"
 );
 validate_xt!(
     proxy_add_proxy("15FEzAVAanaAGtVZLEDMeRKdKipwQrTCpJd1k6k4WP4LhXgT"),

--- a/tests/integrations/westend.rs
+++ b/tests/integrations/westend.rs
@@ -27,17 +27,10 @@ validate_xt!(
     balance_transfer("5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe"),
     "0x040000ff0011afc404c2f8c72ec8bcdeb64d6367822bf3a205a9ac4c1b17ffa75c3f0fa10f"
 );
-validate_xt!(
-    staking_bond("5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe"),
-    "0x060000ff0011afc404c2f8c72ec8bcdeb64d6367822bf3a205a9ac4c1b17ffa75c3f0fa10f01"
-);
+validate_xt!(staking_bond(), "0x0600a10f01");
 validate_xt!(
     staking_nominate("5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe"),
     "0x06050400ff0011afc404c2f8c72ec8bcdeb64d6367822bf3a205a9ac4c1b17ffa75c3f0f"
-);
-validate_xt!(
-    staking_set_controller("5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe"),
-    "0x060800ff0011afc404c2f8c72ec8bcdeb64d6367822bf3a205a9ac4c1b17ffa75c3f0f"
 );
 validate_xt!(
     proxy_add_proxy("5Hq465EqSK865f4cHMgDpuKZf45ukuUshFxAPCCzmJEoBoNe"),

--- a/tests/integrations/xt.rs
+++ b/tests/integrations/xt.rs
@@ -6,8 +6,8 @@ use pdotc::network::SubstrateNetwork;
 use pdotc::pallets::balances::ComposedTransfer;
 use pdotc::pallets::staking::{
     ComposedStakingBond, ComposedStakingBondExtra, ComposedStakingChill, ComposedStakingNominate,
-    ComposedStakingRebond, ComposedStakingSetController, ComposedStakingUnbond,
-    ComposedStakingWithdrawUnbonded, RewardDestination,
+    ComposedStakingRebond, ComposedStakingUnbond, ComposedStakingWithdrawUnbonded,
+    RewardDestination,
 };
 use pdotc::rpc::RpcClient;
 use pdotc::ss58::Ss58Codec;
@@ -27,15 +27,9 @@ pub fn balance_transfer<S: Signer, Client: RpcClient, N: SubstrateNetwork>(
 
 pub fn staking_bond<S: Signer, Client: RpcClient, N: SubstrateNetwork>(
     api: &Api<S, Client, N>,
-    addr: &str,
 ) -> UncheckedExtrinsic<ComposedStakingBond> {
-    api.staking_bond(
-        MultiAddress::Id(AccountId32::from_ss58check_with_version(addr).unwrap().0),
-        1000,
-        RewardDestination::Stash,
-        None,
-    )
-    .unwrap()
+    api.staking_bond(1000, RewardDestination::Stash, None)
+        .unwrap()
 }
 pub fn staking_bond_extra<S: Signer, Client: RpcClient, N: SubstrateNetwork>(
     api: &Api<S, Client, N>,
@@ -72,17 +66,6 @@ pub fn staking_chill<S: Signer, Client: RpcClient, N: SubstrateNetwork>(
     api: &Api<S, Client, N>,
 ) -> UncheckedExtrinsic<ComposedStakingChill> {
     api.staking_chill(None).unwrap()
-}
-
-pub fn staking_set_controller<S: Signer, Client: RpcClient, N: SubstrateNetwork>(
-    api: &Api<S, Client, N>,
-    addr: &str,
-) -> UncheckedExtrinsic<ComposedStakingSetController> {
-    api.staking_set_controller(
-        MultiAddress::Id(AccountId32::from_ss58check_with_version(addr).unwrap().0),
-        None,
-    )
-    .unwrap()
 }
 
 pub fn staking_rebond<S: Signer, Client: RpcClient, N: SubstrateNetwork>(


### PR DESCRIPTION
Since Westend has removed the parameter to set a staking bond and to set controller, there is no need for these any longer once Polkadot and Kusama catch up. Similar functionality can be performed with proxy accounts anyway.

If these mainnets choose not to follow Westend (unlikely?), the code should be refactored using metadata-based code generation like in the official subxt crate.