### PR TITLE
feat: Add join_identity_as_key

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -30,6 +30,10 @@ pub trait SubstrateNetwork: Clone + Copy + 'static {
     const PROXY_REMOVE_PROXIES: u8 = 3;
     type ProxyDelegateType: Encode + Decode + Clone + FromStr<Err = &'static str>;
     type ProxyTypeType: Encode + Decode + Clone + FromStr<Err = &'static str>;
+
+    // Identity Pallet
+    const IDENTITY_PALLET_IDX: u8 = 7;
+    const IDENTITY_JOIN_AS_KEY: u8 = 5;
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/pallets.rs
+++ b/src/pallets.rs
@@ -7,6 +7,7 @@ use crate::rpc::RpcClient;
 use crate::{Era, GenericExtra, SignedPayload, UncheckedExtrinsic};
 
 pub mod balances;
+pub mod identity;
 pub mod proxy;
 pub mod staking;
 pub mod storage;

--- a/src/pallets/identity.rs
+++ b/src/pallets/identity.rs
@@ -1,0 +1,18 @@
+use crate::client::{Api, Result, Signer};
+use crate::network::SubstrateNetwork;
+use crate::pallets::CallIndex;
+use crate::rpc::RpcClient;
+use crate::UncheckedExtrinsic;
+
+pub type ComposedJoinIdentity = (CallIndex, u64);
+
+impl<S: Signer, Client: RpcClient, N: SubstrateNetwork> Api<'_, S, Client, N> {
+    pub fn join_identity_as_key(
+        &self,
+        auth_id: u64,
+        nonce: Option<u32>,
+    ) -> Result<UncheckedExtrinsic<ComposedJoinIdentity>> {
+        let call = ([N::IDENTITY_PALLET_IDX, N::IDENTITY_JOIN_AS_KEY], auth_id);
+        self._create_xt(call, nonce)
+    }
+}


### PR DESCRIPTION
Description
To accept a request to be added as secondary to an existing and verified account on polymesh the secondary account needs to submit the extrinsic join_identity_as_key.

Implementation Details:
- Add identity pallet
- Add function join_identity_as_key to identity pallet
- Add `IDENTITY_PALLET_IDX` to `SubstrateNetwork` trait, default = 7
- Add `IDENTITY_JOIN_AS_KEY` to `SubstrateNetwork` trait, default = 5